### PR TITLE
Add extra copy functionality

### DIFF
--- a/copier.js
+++ b/copier.js
@@ -6,9 +6,11 @@ function copyMain() {
     var editor = vscode.window.activeTextEditor;
     shared.testNoTab(editor);
 
+    var currentFilePath = editor.document.uri.fsPath;
+
     var reusableString = shared.getThingString(editor);
 
-    if (reusableString != "") {
+    if (reusableString) {
         // console.log('reusableString = ' + reusableString);
 
         // Write to clipboard
@@ -20,6 +22,74 @@ function copyMain() {
 
         // set the selection to range of the reusableString
         editor.selection = new vscode.Selection(reusableStringRange.start, reusableStringRange.end);
+    }
+    // Else, see if we are in a reusable/variable/feature flag file
+    else if (shared.reusableOrVariableOrFeatureFlagPathRegex.test(currentFilePath)) {
+        // console.log('current file path = ' + editor.document.uri.fsPath);
+
+        var regexMatchArray = currentFilePath.match(shared.reusableOrVariableOrFeatureFlagPathRegex);
+
+        // console.log('type = ' + regexMatchArray[1]);
+
+        // The first matching group in the regex is the directory of the type of thing: either `reusables`, `variables`, or `features`
+        switch (regexMatchArray[1]) {
+            case 'reusables':
+                //console.log('reusable path = ' + regexMatchArray[2]);
+
+                // Replace directory separators (for both *nix and Windows) with dots
+                var reusablePath = regexMatchArray[2].replace(/(\/|\\)/g, '.');
+                // strip the `.md` file extension
+                reusablePath = reusablePath.replace(/.md$/,"");
+
+                //console.log('revised reusable path = ' + reusablePath);
+
+                // Construct the reusable reference
+                var reusableReference = '{% data reusables.' + reusablePath + ' %}';
+
+                // Copy it to the clipboard and display a message:
+                vscode.env.clipboard.writeText(reusableReference);
+                vscode.window.showInformationMessage("Reusable reference copied to clipboard.");
+                break;
+            case 'variables':
+                // replace directory separators (for both *nix and Windows) with dots
+                var variablePath = regexMatchArray[2].replace(/(\/|\\)/g, '.');
+                // strip the `.yml` file extension
+                variablePath = variablePath.replace(/.yml$/,"");
+
+                //console.log('variable file path = ' + variablePath);
+
+                // Make sure the current line contains a variable definition
+                if (shared.variableDefinitionNameRegex.test(editor.document.lineAt(editor.selection.active.line).text)) {
+                    // Get the variable name from the current line
+                    var variableName = editor.document.lineAt(editor.selection.active.line).text.match(shared.variableDefinitionNameRegex);
+                    
+                    // console.log('variable name = ' + variableName[1]);
+
+                    // Construct the variable reference
+                    var variableReference = '{% data variables.' + variablePath + '.' + variableName[1] + ' %}';
+
+                    // console.log('variableReference = ' + variableReference);
+
+                    // Copy it to the clipboard and display a message:
+                    vscode.env.clipboard.writeText(variableReference);
+                    vscode.window.showInformationMessage("Variable reference copied to clipboard.");
+                } else {
+                    vscode.window.showInformationMessage("Cursor is not on a variable definition line.");
+                }
+                break;
+            case 'features':
+                // This gets the file name from the path (without the file extension)
+                var featureFlagName = regexMatchArray[2].match(/[^/\\]*?(?=\.[^./\\]*$|$)/)[0];
+
+                //console.log('feature flag = ' + featureFlagName);
+
+                //Construct versioning uusing feature flag reference
+                var featureFlagReference = '{% ifversion ' + featureFlagName + ' %}{% endif %}';
+                // Copy it to the clipboard and display a message:
+                vscode.env.clipboard.writeText(featureFlagReference);
+                vscode.window.showInformationMessage("Feature flag versioning copied to clipboard.");
+                break;
+        }
     }
     else {
         vscode.window.showInformationMessage("Cursor is not within a reusable, variable, or feature flag.");

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
 		"commands": [
 			{
 				"command": "open-reusable",
-				"title": "Open reusable file"
+				"title": "open-reusables: Open reusable file"
 			},
 			{
 				"command": "copy-reusable",
-				"title": "Copy the reusable at the cursor position"
+				"title": "open-reusables: Copy the reusable, variable, or feature flag at the cursor position"
 			}			
 		],
         "keybindings": [

--- a/shared.js
+++ b/shared.js
@@ -18,6 +18,16 @@ const liquidTagRegex = /{%([^%])*%}/;
 // - feature: <something>
 const frontmatterFeatureFlagRegex = /^ *feature: '*([^ ']*)'* *$/;
 
+// This regex matches paths to a reusable, variable, or feature flag. e.g.:
+// - data/reusables/<something>
+// - data/variables/<something>
+// - data/features/<something>
+// As well as the same paths with a backslash as the directory separator.
+const reusableOrVariableOrFeatureFlagPathRegex = /data.(reusables|variables|features).(.+)/;
+
+// This regex matches the name of a variable definition on a line in a variable file. e.g.: 
+const variableDefinitionNameRegex = /^([^:]*):/;
+
 /* Gets the type and value of a reusable or feature flag.
    Returns an array with the type and value.
 
@@ -110,5 +120,7 @@ function getThingString(editor) {
 module.exports = {
     testNoTab,
     getTypeAndValue,
-    getThingString
+    getThingString,
+    reusableOrVariableOrFeatureFlagPathRegex,
+    variableDefinitionNameRegex
 };


### PR DESCRIPTION
This change generates a reference for a reusable, variable, or feature flag based on the cursor's position:

* If in a reusable file, this creates the `{% data reusables.path.to.reusable %}` reference and copies it to the clipboard.
* If in a variables file and on a variable definition line, this creates the `{% data variables.path.to.reusables.variable-name %}` reference and copies it to the clipboard.
* If in a feature flag file, this creates a versioning tag like `{% ifversion featureFlagName %}{% endif %}` and copies it to the clipboard.